### PR TITLE
Fix typo in `login` verb description

### DIFF
--- a/cmd/ccboc/cmd/root.go
+++ b/cmd/ccboc/cmd/root.go
@@ -29,7 +29,7 @@ var (
 
 	loginCmd = &cobra.Command{
 		Use:              "login",
-		Short:            "Login to api server using the provided url and token. Also it generates the configuration file (default path is $HOME/.config/ccbo/config)",
+		Short:            "Login to api server using the provided url and token. Also it generates the configuration file (default path is $HOME/.config/ccboc/config)",
 		TraverseChildren: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := login()


### PR DESCRIPTION
I have discovered an apparent typo in the `login` verb description, so I am making a quick fix.